### PR TITLE
Fix gulp-sass dependency for newer node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Building City Dashboard
 * Make sure you have the node package manager installed
 * Clone this repo
 ```bash
-> git clone https://github.com/niclabs/city-dashboard.git
+> git clone https://github.com/niclabs/insight.git
 ```
 
 * Install developer dependencies

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-jshint": "^1.9.2",
     "gulp-notify": "^2.2.0",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.0",
     "gulp-uglify": "^1.1.0",
     "qunitjs": "^1.17.1"
   },


### PR DESCRIPTION
If you try to build the project with newer node versions (AKA node v4.x) you will run into issues when installing the dependencies for the older gulp-sass, so I updated the version in the package.json file...